### PR TITLE
feat: replace most booked venue with highest rated venue in home repo…

### DIFF
--- a/lib/repositories/home_repository.dart
+++ b/lib/repositories/home_repository.dart
@@ -39,28 +39,29 @@ class HomeRepository {
     final data = metadata.data() ?? {};
     Map<String, dynamic> sportsBookings = data['sports_bookings'] ?? {};
 
-    Map<String, dynamic> venuesBookings = data['venues_bookings'] ?? {};
-
     var mostBookedSport =
         sportsBookings.entries.reduce((a, b) => a.value > b.value ? a : b);
-    var mostBookedVenue =
-        venuesBookings.entries.reduce((a, b) => a.value > b.value ? a : b);
-
+    
     final mostBookedSportDoc =
         _firestore.collection('sports').doc(mostBookedSport.key).get();
-    final mostBookedVenueDoc =
-        _firestore.collection('venues').doc(mostBookedVenue.key).get();
+    
+    final highestRatedVenueDoc = await _firestore
+      .collection('venues')
+      .orderBy('rating', descending: true)
+      .limit(1)
+      .get();
 
     // to json (Model)
     final mostBookedSportModel =
         SportModel.fromJson((await mostBookedSportDoc).data() ?? {});
-    final mostBookedVenueModel =
-        VenueModel.fromJson((await mostBookedVenueDoc).data() ?? {});
+    
+    final highestRatedVenueModel = VenueModel.fromJson(highestRatedVenueDoc.docs.first.data());
+    
 
     if (user.bookings.isEmpty) {
       return {
         'mostBookedSport': mostBookedSportModel,
-        'mostBookedVenue': mostBookedVenueModel,
+        'highestRatedVenue': highestRatedVenueModel,
         'mostPlayedSport': null
       };
     }
@@ -77,11 +78,9 @@ class HomeRepository {
       }
     }
 
-    print("aaaaaaa ${mostBookedVenueModel.name}");
-
     return {
       'mostBookedSport': mostBookedSportModel,
-      'mostBookedVenue': mostBookedVenueModel,
+      'highestRatedVenue': highestRatedVenueModel,
       'mostPlayedSport': mostPlayedSport
     };
   }

--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -89,9 +89,9 @@ class HomeView extends StatelessWidget {
                     sport: popularityReport['mostBookedSport'],
                     title: 'Most Booked Sport Overall',
                   ),
-                if (popularityReport['mostBookedVenue'] != null)
+                if (popularityReport['highestRatedVenue'] != null)
                   VenuePopularityReportCardWidget(
-                    venue: popularityReport['mostBookedVenue'],
+                    venue: popularityReport['highestRatedVenue'],
                     title: 'Best Rated Overall',
                   ),
                 if (popularityReport['mostPlayedSport'] != null)


### PR DESCRIPTION
This pull request updates the `HomeRepository` and `HomeView` classes to replace the "most booked venue" with the "highest rated venue". The most important changes include modifying the logic to fetch and display the highest rated venue instead of the most booked venue.

Changes in `lib/repositories/home_repository.dart`:

* Removed logic for fetching the most booked venue and replaced it with logic to fetch the highest rated venue.
* Updated the return values to include the highest rated venue instead of the most booked venue.

Changes in `lib/views/home_view.dart`:

* Updated the `HomeView` class to display the highest rated venue instead of the most booked venue in the `VenuePopularityReportCardWidget`.