### PR TITLE
feat: update home repository to track most booked venue 

### DIFF
--- a/lib/repositories/home_repository.dart
+++ b/lib/repositories/home_repository.dart
@@ -37,13 +37,14 @@ class HomeRepository {
         await _firestore.collection('metadata').doc('metadata').get();
 
     final data = metadata.data() ?? {};
-    Map<String, dynamic> sportsBookings = data['sports_bookings'] ?? {};
-
-    var mostBookedSport =
-        sportsBookings.entries.reduce((a, b) => a.value > b.value ? a : b);
     
-    final mostBookedSportDoc =
-        _firestore.collection('sports').doc(mostBookedSport.key).get();
+    Map<String, dynamic> venuesBookings = data['venues_bookings'] ?? {};
+  
+    var mostBookedVenue =
+      venuesBookings.entries.reduce((a, b) => a.value > b.value ? a : b);
+    
+    final mostBookedVenueDoc =
+      _firestore.collection('venues').doc(mostBookedVenue.key).get();
     
     final highestRatedVenueDoc = await _firestore
       .collection('venues')
@@ -52,16 +53,16 @@ class HomeRepository {
       .get();
 
     // to json (Model)
-    final mostBookedSportModel =
-        SportModel.fromJson((await mostBookedSportDoc).data() ?? {});
+    final mostBookedVenueModel =
+      VenueModel.fromJson((await mostBookedVenueDoc).data() ?? {});
     
     final highestRatedVenueModel = VenueModel.fromJson(highestRatedVenueDoc.docs.first.data());
     
 
     if (user.bookings.isEmpty) {
       return {
-        'mostBookedSport': mostBookedSportModel,
         'highestRatedVenue': highestRatedVenueModel,
+        'mostBookedVenue': mostBookedVenueModel,
         'mostPlayedSport': null
       };
     }
@@ -79,8 +80,8 @@ class HomeRepository {
     }
 
     return {
-      'mostBookedSport': mostBookedSportModel,
       'highestRatedVenue': highestRatedVenueModel,
+      'mostBookedVenue': mostBookedVenueModel,
       'mostPlayedSport': mostPlayedSport
     };
   }

--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -84,11 +84,6 @@ class HomeView extends StatelessWidget {
             scrollDirection: Axis.horizontal,
             child: Row(
               children: <Widget>[
-                if (popularityReport['mostBookedSport'] != null)
-                  SportPopularityReportCardWidget(
-                    sport: popularityReport['mostBookedSport'],
-                    title: 'Most Booked Sport Overall',
-                  ),
                 if (popularityReport['highestRatedVenue'] != null)
                   VenuePopularityReportCardWidget(
                     venue: popularityReport['highestRatedVenue'],
@@ -98,6 +93,11 @@ class HomeView extends StatelessWidget {
                   SportPopularityReportCardWidget(
                     sport: popularityReport['mostPlayedSport'],
                     title: 'Most Played by You',
+                  ),
+                if (popularityReport['mostBookedVenue'] != null)
+                  VenuePopularityReportCardWidget(
+                    venue: popularityReport['mostBookedVenue'],
+                    title: 'Most Booked Overall',
                   ),
               ],
             ),

--- a/lib/widgets/sport_popularity_report_widget.dart
+++ b/lib/widgets/sport_popularity_report_widget.dart
@@ -32,13 +32,14 @@ class SportPopularityReportCardWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return SizedBox(
       width: 150.0,
+      height: 170.0,
       child: Card(
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(10.0),
         ),
         color: AppColors.lightPurple,
         child: Padding(
-          padding: const EdgeInsets.all(16.0),
+          padding: const EdgeInsets.all(8.0),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/widgets/venue_popularity_report_widget.dart
+++ b/lib/widgets/venue_popularity_report_widget.dart
@@ -17,13 +17,14 @@ class VenuePopularityReportCardWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return SizedBox(
       width: 150.0,
+      height: 170.0,
       child: Card(
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(10.0),
         ),
         color: AppColors.lightPurple,
         child: Padding(
-          padding: const EdgeInsets.all(16.0),
+          padding: const EdgeInsets.all(8.0),
           child: Column(
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.center,


### PR DESCRIPTION
This pull request includes changes to the `HomeRepository` and related view and widget files to shift the focus from sports bookings to venue bookings. The most important changes include updating the data fetching and processing logic in `HomeRepository`, modifying the `HomeView` to reflect these changes, and adjusting the layout of the report card widgets.

Changes to data fetching and processing in `HomeRepository`:

* [`lib/repositories/home_repository.dart`](diffhunk://#diff-cd70e0349a6ba7269a9fcdf8af4b7a1c426c44999900530e2768b08d449595f3L40-R47): Replaced `sportsBookings` with `venuesBookings` and updated related logic to fetch and process the most booked venue instead of the most booked sport. [[1]](diffhunk://#diff-cd70e0349a6ba7269a9fcdf8af4b7a1c426c44999900530e2768b08d449595f3L40-R47) [[2]](diffhunk://#diff-cd70e0349a6ba7269a9fcdf8af4b7a1c426c44999900530e2768b08d449595f3L55-R65) [[3]](diffhunk://#diff-cd70e0349a6ba7269a9fcdf8af4b7a1c426c44999900530e2768b08d449595f3L82-R84)

Changes to the view:

* [`lib/views/home_view.dart`](diffhunk://#diff-54f71829c5bd0c9e830cf92e23e2a25f5ebbffef03af5d0dd9ab6c0b7ed88279L87-L91): Removed the display of the most booked sport and added the display of the most booked venue in the `HomeView`. [[1]](diffhunk://#diff-54f71829c5bd0c9e830cf92e23e2a25f5ebbffef03af5d0dd9ab6c0b7ed88279L87-L91) [[2]](diffhunk://#diff-54f71829c5bd0c9e830cf92e23e2a25f5ebbffef03af5d0dd9ab6c0b7ed88279R97-R101)

![image](https://github.com/user-attachments/assets/c846ca3b-401c-4505-a96c-cdb8e30ea104)
![Screenshot_1742520291](https://github.com/user-attachments/assets/01690eb4-b59f-49ee-8e42-d7eb25df4ddd)

