### PR TITLE
fix: search view pixel overflow

### DIFF
--- a/lib/widgets/search_view_widgets/sport_button_widget.dart
+++ b/lib/widgets/search_view_widgets/sport_button_widget.dart
@@ -35,8 +35,9 @@ class SportButtonWidget extends StatelessWidget {
         context.go('/venue_list/${sport.name}');
       },
       child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: 15, horizontal: 0),
+        padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 5),
         child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
             SvgPicture.asset(
               imageAsset,
@@ -44,15 +45,21 @@ class SportButtonWidget extends StatelessWidget {
               height: size,
               color: Colors.white,
             ),
-            const SizedBox(
-              height: 15,
-            ),
-            Text(text,
-                style: const TextStyle(
+            const SizedBox(height: 10),
+            Flexible(
+              child: FittedBox(
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  text,
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
                     fontSize: 14,
                     fontWeight: FontWeight.bold,
-                    color: Colors.white)
-            )
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
This pull request includes a few important changes to the `SportButtonWidget` in the `lib/widgets/search_view_widgets/sport_button_widget.dart` file. The changes focus on improving the layout and appearance of the widget.

Layout and appearance improvements:

* Adjusted padding to `EdgeInsets.symmetric(vertical: 10, horizontal: 5)` for better spacing.
* Added `mainAxisSize: MainAxisSize.min` to the `Column` to ensure it takes up the minimum amount of space required.
* Replaced the `SizedBox` with height `15` with a `SizedBox` of height `10` for more compact spacing.
* Wrapped the `Text` widget in a `Flexible` widget with a `FittedBox` to ensure the text scales down and stays centered, improving text layout and readability.