### PR TITLE
fix: search view scrollable

### DIFF
--- a/lib/views/search_view.dart
+++ b/lib/views/search_view.dart
@@ -52,20 +52,26 @@ class SearchView extends StatelessWidget {
   }
 
   Widget _buildSportButtons(List<SportModel> sports) {
-    return GridView.count(
-      crossAxisCount: 2,
-      shrinkWrap: true,
-      mainAxisSpacing: 10.0,
-      crossAxisSpacing: 10.0,
-      padding: const EdgeInsets.all(20.0),
-      children: sports.map((sport) {
-        return SportButtonWidget(
-          text: sport.name,
-          imageAsset: sport.logo,
-          sport: sport,
-          size: 110,
-        );
-      }).toList(),
+    return SingleChildScrollView(
+      child: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: GridView.count(
+          crossAxisCount: 2,
+          shrinkWrap: true,
+          physics:
+              const NeverScrollableScrollPhysics(), // Prevent GridView from scrolling
+          mainAxisSpacing: 10.0,
+          crossAxisSpacing: 10.0,
+          children: sports.map((sport) {
+            return SportButtonWidget(
+              text: sport.name,
+              imageAsset: sport.logo,
+              sport: sport,
+              size: 110,
+            );
+          }).toList(),
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
This pull request includes changes to the `SearchView` class in the `lib/views/search_view.dart` file to improve the layout and user experience of the sport buttons.

Layout improvements:

* Replaced `GridView.count` with `SingleChildScrollView` wrapped in `Padding` to allow for better layout control and to prevent the `GridView` from scrolling independently.
* Added padding around the `GridView` and set `NeverScrollableScrollPhysics` to prevent the `GridView` from scrolling, ensuring a more consistent user experience.