### PR TITLE
refactor(crashlytics): include current view info using setCustomKey

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,7 +29,9 @@ Future main() async {
   await FirebaseAppCheck.instance
       .activate(androidProvider: AndroidProvider.playIntegrity);
 
-  FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterFatalError;
+  FlutterError.onError = (FlutterErrorDetails details) async {
+    FirebaseCrashlytics.instance.recordFlutterFatalError(details);
+  };
 
   Bloc.observer = AppBlocObserver();
 

--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:isis3510_team32_flutter/core/app_colors.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -16,6 +17,8 @@ class HomeView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    FirebaseCrashlytics.instance.setCustomKey('screen', 'Home View');
+
     return BlocProvider(
       create: (context) => HomeBloc(
           authBloc: context.read<AuthBloc>(), homeRepository: HomeRepository())

--- a/lib/views/initiation_view.dart
+++ b/lib/views/initiation_view.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -19,6 +20,8 @@ class InitiationView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    FirebaseCrashlytics.instance.setCustomKey('screen', 'Initiation View');
+
     final size = MediaQuery.of(context).size;
     final aspectRatio = size.width / size.height;
 

--- a/lib/views/login_view.dart
+++ b/lib/views/login_view.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:isis3510_team32_flutter/core/app_colors.dart';
 import 'package:isis3510_team32_flutter/widgets/google_sign_in_widget.dart';
@@ -7,6 +8,8 @@ class LoginView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    FirebaseCrashlytics.instance.setCustomKey('screen', 'Login View');
+
     final size = MediaQuery.of(context).size;
     final aspectRatio = size.width / size.height;
 

--- a/lib/views/profile_view.dart
+++ b/lib/views/profile_view.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:isis3510_team32_flutter/view_models/auth/auth_bloc.dart';
@@ -9,6 +10,8 @@ class ProfileView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    FirebaseCrashlytics.instance.setCustomKey('screen', 'Profile View');
+
     final authBloc = context.read<AuthBloc>();
 
     return Scaffold(

--- a/lib/views/search_view.dart
+++ b/lib/views/search_view.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:isis3510_team32_flutter/widgets/bottom_navigation_widget.dart';
 import 'package:isis3510_team32_flutter/widgets/search_view_widgets/sport_button_widget.dart';
@@ -11,6 +12,8 @@ class SearchView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    FirebaseCrashlytics.instance.setCustomKey('screen', 'Search View');
+
     return BlocProvider(
       create: (context) => SearchBloc()..add(const LoadSearchData()),
       child: Scaffold(

--- a/lib/views/venue_list_view.dart
+++ b/lib/views/venue_list_view.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:isis3510_team32_flutter/widgets/bottom_navigation_widget.dart';
 import 'package:isis3510_team32_flutter/core/app_colors.dart';
@@ -15,6 +16,9 @@ class VenueListView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    FirebaseCrashlytics.instance
+        .setCustomKey('screen', '$sportName Venue List View');
+
     return BlocProvider(
       create: (context) => VenueListBloc(
           sportName: sportName, venueRepository: VenueRepository())


### PR DESCRIPTION
This pull request introduces enhancements to Firebase Crashlytics integration across the app, ensuring better error reporting and analytics by setting custom keys for screen tracking and improving error handling. 

![imagen](https://github.com/user-attachments/assets/a275d717-02ab-4538-afcc-7ded338bb16f)
