### PR TITLE
Chore: Modify minimum age for registration

### DIFF
--- a/lib/widgets/initiation_date_picker_widget.dart
+++ b/lib/widgets/initiation_date_picker_widget.dart
@@ -39,9 +39,9 @@ class InitiationDatePicker extends StatelessWidget {
           BuildContext context, InitiationBloc initiationBloc) async =>
       showDatePicker(
         context: context,
-        initialDate: DateTime.now().subtract(const Duration(days: 365 * 3)),
+        initialDate: DateTime.now().subtract(const Duration(days: 365 * 7)),
         firstDate: DateTime(DateTime.now().year - 120),
-        lastDate: DateTime.now().subtract(const Duration(days: 365 * 3)),
+        lastDate: DateTime.now().subtract(const Duration(days: 365 * 7)),
       ).then((DateTime? selected) {
         if (selected != null && selected != initiationBloc.state.birthDate) {
           initiationBloc.add(InitiationAgeEvent(selected));


### PR DESCRIPTION
# Why?

Currently, there is a minimum age of 3 years old for the user to register on the application. As told by the professor, this is way too low for the kind of app we are developing. This PR sets the minimum registration age to be 7 years old.