### PR TITLE
fix: back button behavior

### DIFF
--- a/lib/views/venue_list_view.dart
+++ b/lib/views/venue_list_view.dart
@@ -36,7 +36,7 @@ class VenueListView extends StatelessWidget {
           leading: IconButton(
             icon: const Icon(Icons.arrow_back, color: AppColors.primary),
             onPressed: () {
-              context.go('/search');
+              context.push('/search');
             },
           ),
           title: Text('$formattedSportName Venues',

--- a/lib/widgets/bottom_navigation_widget.dart
+++ b/lib/widgets/bottom_navigation_widget.dart
@@ -1,45 +1,35 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
-import 'package:isis3510_team32_flutter/core/app_colors.dart';
 import 'package:go_router/go_router.dart';
+import 'package:isis3510_team32_flutter/core/app_colors.dart';
 
-class BottomNavigationWidget extends StatefulWidget {
-  final int selectedIndex; // Add selectedIndex parameter
+class BottomNavigationWidget extends StatelessWidget {
+  final int selectedIndex;
 
-  const BottomNavigationWidget({super.key, required this.selectedIndex});
+  const BottomNavigationWidget({
+    super.key,
+    required this.selectedIndex,
+  });
 
-  @override
-  BottomNavigationWidgetState createState() => BottomNavigationWidgetState();
-}
-
-class BottomNavigationWidgetState extends State<BottomNavigationWidget> {
-  late int _selectedIndex;
-
-  @override
-  void initState() {
-    super.initState();
-    _selectedIndex = widget.selectedIndex; // Initialize with parameter value
-  }
-
-  void _onItemTapped(int index) {
-    setState(() {
-      _selectedIndex = index;
-    });
+  void _onItemTapped(BuildContext context, int index) {
+    if (index == selectedIndex) {
+      return;
+    }
     switch (index) {
-       case 0:
-         context.go('/search');
-      //   break;
+      case 0:
+        context.push('/search');
+        break;
       // case 1:
-      //   context.go('/calendar');
+      //   context.push('/calendar');
       //   break;
       case 2:
-        context.go('/home');
+        context.push('/home');
         break;
       // case 3:
-      //   context.go('/add');
+      //   context.push('/add');
       //   break;
       case 4:
-        context.go('/profile');
+        context.push('/profile');
         break;
     }
   }
@@ -53,58 +43,48 @@ class BottomNavigationWidgetState extends State<BottomNavigationWidget> {
         children: [
           IconButton(
             icon: SvgPicture.asset(
-              _selectedIndex == 0
+              selectedIndex == 0
                   ? 'assets/icons/navbar/search-selected.svg'
                   : 'assets/icons/navbar/search.svg',
               color: AppColors.primary,
             ),
-            onPressed: () {
-              _onItemTapped(0);
-            },
+            onPressed: () => _onItemTapped(context, 0),
           ),
           IconButton(
             icon: SvgPicture.asset(
-              _selectedIndex == 1
+              selectedIndex == 1
                   ? 'assets/icons/navbar/calendar-selected.svg'
                   : 'assets/icons/navbar/calendar.svg',
               color: AppColors.primary,
             ),
-            onPressed: () {
-              _onItemTapped(1);
-            },
+            onPressed: () => _onItemTapped(context, 1),
           ),
           IconButton(
             icon: SvgPicture.asset(
-              _selectedIndex == 2
+              selectedIndex == 2
                   ? 'assets/icons/navbar/home-selected.svg'
                   : 'assets/icons/navbar/home.svg',
               color: AppColors.primary,
             ),
-            onPressed: () {
-              _onItemTapped(2);
-            },
+            onPressed: () => _onItemTapped(context, 2),
           ),
           IconButton(
             icon: SvgPicture.asset(
-              _selectedIndex == 3
+              selectedIndex == 3
                   ? 'assets/icons/navbar/add-selected.svg'
                   : 'assets/icons/navbar/add.svg',
               color: AppColors.primary,
             ),
-            onPressed: () {
-              _onItemTapped(3);
-            },
+            onPressed: () => _onItemTapped(context, 3),
           ),
           IconButton(
             icon: SvgPicture.asset(
-              _selectedIndex == 4
+              selectedIndex == 4
                   ? 'assets/icons/navbar/profile-selected.svg'
                   : 'assets/icons/navbar/profile.svg',
               color: AppColors.primary,
             ),
-            onPressed: () {
-              _onItemTapped(4);
-            },
+            onPressed: () => _onItemTapped(context, 4),
           ),
         ],
       ),

--- a/lib/widgets/search_view_widgets/sport_button_widget.dart
+++ b/lib/widgets/search_view_widgets/sport_button_widget.dart
@@ -32,7 +32,7 @@ class SportButtonWidget extends StatelessWidget {
         ),
       ),
       onPressed: () {
-        context.go('/venue_list/${sport.name}');
+        context.push('/venue_list/${sport.name}');
       },
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 5),


### PR DESCRIPTION
This pull request refactors navigation logic by replacing `context.go` with `context.push` across multiple components and simplifies the `BottomNavigationWidget` by converting it from a stateful to a stateless widget. These changes improve navigation consistency and streamline the widget's implementation.

### Navigation Refactor:
* Replaced `context.go` with `context.push` in the `VenueListView`'s back button navigation (`lib/views/venue_list_view.dart`).
* Updated the `SportButtonWidget` to use `context.push` for navigating to the venue list (`lib/widgets/search_view_widgets/sport_button_widget.dart`).
* Modified navigation logic in `BottomNavigationWidget` to use `context.push` for route transitions (`lib/widgets/bottom_navigation_widget.dart`). [[1]](diffhunk://#diff-9a14f8259a31c1c27117ec045c535b79a503bd4df062a5459fd064cfa567867dL3-R32) [[2]](diffhunk://#diff-9a14f8259a31c1c27117ec045c535b79a503bd4df062a5459fd064cfa567867dL56-R87)

### Code Simplification:
* Refactored `BottomNavigationWidget` from a stateful to a stateless widget, removing unnecessary state management and simplifying the `_onItemTapped` method (`lib/widgets/bottom_navigation_widget.dart`).