### PR TITLE
feat: enhance venue popularity report with subtitles for better context

### DIFF
--- a/lib/views/home_view.dart
+++ b/lib/views/home_view.dart
@@ -89,9 +89,11 @@ class HomeView extends StatelessWidget {
               children: <Widget>[
                 if (popularityReport['highestRatedVenue'] != null)
                   VenuePopularityReportCardWidget(
-                    venue: popularityReport['highestRatedVenue'],
-                    title: 'Best Rated Overall',
-                  ),
+                      venue: popularityReport['highestRatedVenue'],
+                      title: 'Best Rated Overall',
+                      subtitle: popularityReport['highestRatedVenue']
+                          .rating
+                          .toString()),
                 if (popularityReport['mostPlayedSport'] != null)
                   SportPopularityReportCardWidget(
                     sport: popularityReport['mostPlayedSport'],
@@ -102,6 +104,8 @@ class HomeView extends StatelessWidget {
                   VenuePopularityReportCardWidget(
                     venue: popularityReport['mostBookedVenue'],
                     title: 'Most Booked Overall',
+                    subtitle:
+                        "${popularityReport['mostBookedVenue'].bookings.length.toString()} bookings",
                   ),
               ],
             ),

--- a/lib/widgets/bottom_navigation_widget.dart
+++ b/lib/widgets/bottom_navigation_widget.dart
@@ -12,7 +12,7 @@ class BottomNavigationWidget extends StatelessWidget {
   });
 
   void _onItemTapped(BuildContext context, int index) {
-    if (index == selectedIndex) {
+    if (index == selectedIndex && index != 0) {
       return;
     }
     switch (index) {

--- a/lib/widgets/venue_popularity_report_widget.dart
+++ b/lib/widgets/venue_popularity_report_widget.dart
@@ -6,11 +6,13 @@ import 'package:isis3510_team32_flutter/models/venue_model.dart';
 class VenuePopularityReportCardWidget extends StatelessWidget {
   final VenueModel venue;
   final String title;
+  final String subtitle;
 
   const VenuePopularityReportCardWidget({
     super.key,
     required this.venue,
     required this.title,
+    required this.subtitle,
   });
 
   @override
@@ -66,14 +68,16 @@ class VenuePopularityReportCardWidget extends StatelessWidget {
               Row(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  const Icon(
-                    Icons.star,
-                    color: Colors.white,
-                    size: 16.0,
-                  ),
-                  const SizedBox(width: 4.0),
+                  if (subtitle == venue.rating.toString()) ...[
+                    const Icon(
+                      Icons.star,
+                      color: Colors.white,
+                      size: 16.0,
+                    ),
+                    const SizedBox(width: 4.0),
+                  ],
                   Text(
-                    venue.rating.toString(),
+                    subtitle,
                     style: const TextStyle(
                       fontWeight: FontWeight.bold,
                       color: Colors.white,


### PR DESCRIPTION
This pull request enhances the user interface by adding a subtitle property to the `VenuePopularityReportCardWidget` and refining navigation behavior. The most important changes include updating the `VenuePopularityReportCardWidget` to display additional information, such as venue ratings and booking counts, and improving the bottom navigation logic.

### Enhancements to `VenuePopularityReportCardWidget`:

* Added a new `subtitle` property to the `VenuePopularityReportCardWidget` class to display supplementary details like venue ratings or booking counts. (`lib/widgets/venue_popularity_report_widget.dart`, [lib/widgets/venue_popularity_report_widget.dartR9-R15](diffhunk://#diff-13c2b5b980691a0548adc4b3e7b326307882ac43922403c69e4ec1c64b4fc3ecR9-R15))
* Updated the widget's layout to conditionally display a star icon when the subtitle matches the venue's rating, improving visual feedback for users. (`lib/widgets/venue_popularity_report_widget.dart`, [lib/widgets/venue_popularity_report_widget.dartR71-R80](diffhunk://#diff-13c2b5b980691a0548adc4b3e7b326307882ac43922403c69e4ec1c64b4fc3ecR71-R80))
* Modified the `HomeView` to pass appropriate values for the `subtitle` property, such as ratings for the highest-rated venue and booking counts for the most-booked venue. (`lib/views/home_view.dart`, [[1]](diffhunk://#diff-54f71829c5bd0c9e830cf92e23e2a25f5ebbffef03af5d0dd9ab6c0b7ed88279L94-R96) [[2]](diffhunk://#diff-54f71829c5bd0c9e830cf92e23e2a25f5ebbffef03af5d0dd9ab6c0b7ed88279R107-R108)

### Improvements to bottom navigation:

* Adjusted the `_onItemTapped` method in `BottomNavigationWidget` to prevent redundant navigation actions when the user taps the currently selected tab, except for the first tab. (`lib/widgets/bottom_navigation_widget.dart`, [lib/widgets/bottom_navigation_widget.dartL15-R15](diffhunk://#diff-9a14f8259a31c1c27117ec045c535b79a503bd4df062a5459fd064cfa567867dL15-R15))