### PR TITLE
fix: adjust width in ProfileCardTextWidget and update AppBar text col…

### DIFF
--- a/lib/views/profile_view.dart
+++ b/lib/views/profile_view.dart
@@ -386,7 +386,7 @@ class ProfileCardTextWidget extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             SizedBox(
-              width: 230,
+              width: 210,
               child: Text(
                 authState.userModel != null
                     ? authState.userModel!.name

--- a/lib/views/venue_list_view.dart
+++ b/lib/views/venue_list_view.dart
@@ -37,16 +37,19 @@ class VenueListView extends StatelessWidget {
         ..add(const LoadVenueListData()),
       child: Scaffold(
         backgroundColor: AppColors.background(context),
-        appBar:  AppBar(
+        appBar: AppBar(
           leading: IconButton(
-            icon: const Icon(Icons.arrow_back, color: AppColors.primary),
+            icon: Icon(Icons.arrow_back, color: AppColors.titleText(context)),
             onPressed: () {
               context.push('/search');
             },
           ),
-          title: Text('$formattedSportName Venues',
-              style: const TextStyle(
-                  color: AppColors.primary, fontWeight: FontWeight.w600)),
+          title: Text(
+            '$formattedSportName Venues',
+            style: TextStyle(
+                color: AppColors.titleText(context),
+                fontWeight: FontWeight.w600),
+          ),
           centerTitle: true,
           shadowColor: AppColors.text(context),
           elevation: 1,


### PR DESCRIPTION
This pull request makes UI adjustments to improve the visual consistency of the app by modifying widget dimensions and color schemes. The most notable changes include resizing a profile card text widget and updating the color logic for icons and text in the venue list view.

### UI Adjustments:

* [`lib/views/profile_view.dart`](diffhunk://#diff-76242abbe30ee0e85490fb511da266efbd5dbd51b4a939ddf40212acf3062b0aL389-R389): Reduced the width of the `ProfileCardTextWidget` from `230` to `210` for better alignment or layout consistency.
* [`lib/views/venue_list_view.dart`](diffhunk://#diff-a9ef487a8194c95bc7fd9eb2fa0d5cfe0b4cc1e9d8019f1a3ceb81da82d2d9caL42-R52): Updated the color of the back button icon and the title text to use dynamic theme-based colors (`AppColors.titleText(context)`) instead of hardcoded primary color values. This ensures the UI adapts better to different themes.