### PR TITLE
Feat/record screen time

### DIFF
--- a/lib/core/go_router.dart
+++ b/lib/core/go_router.dart
@@ -103,7 +103,9 @@ GoRouter setupRouter(AuthBloc authBloc) {
       GoRoute(
           path: '/initiation',
           pageBuilder: (context, state) => buildPageWithNoTransition(
-              context: context, state: state, child: const InitiationView())),
+              context: context,
+              state: state,
+              child: InitiationView(screenTimeService: screenTimeService))),
       GoRoute(
           path: '/profile',
           pageBuilder: (context, state) => buildPageWithNoTransition(

--- a/lib/core/go_router.dart
+++ b/lib/core/go_router.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:isis3510_team32_flutter/core/screen_time.service.dart';
 import 'package:isis3510_team32_flutter/view_models/auth/auth_bloc.dart';
 import 'package:isis3510_team32_flutter/view_models/auth/auth_router_notifier.dart';
 import 'package:isis3510_team32_flutter/views/create_booking_view.dart';
@@ -26,6 +27,7 @@ CustomTransitionPage buildPageWithNoTransition<T>({
 
 GoRouter setupRouter(AuthBloc authBloc) {
   final authNotifier = AuthRouterNotifier(authBloc);
+  final screenTimeService = ScreenTimeService();
 
   return GoRouter(
     initialLocation: '/login',
@@ -93,7 +95,8 @@ GoRouter setupRouter(AuthBloc authBloc) {
           return buildPageWithNoTransition(
             context: context,
             state: state,
-            child: CreateBookingView(venueId: venueId),
+            child: CreateBookingView(
+                venueId: venueId, screenTimeService: screenTimeService),
           );
         },
       ),

--- a/lib/core/screen_time.service.dart
+++ b/lib/core/screen_time.service.dart
@@ -1,0 +1,57 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+class ScreenTimeService with ChangeNotifier {
+  DateTime? _startTime;
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+
+  // Start tracking time
+  void startTrackingTime() {
+    _startTime = DateTime.now();
+  }
+
+  // Stop tracking time and record it to Firebase
+  Future<void> stopAndRecordTime(String screenName) async {
+    if (_startTime == null) return;
+
+    final timeSpent =
+        DateTime.now().difference(_startTime!).inSeconds.toDouble();
+
+    final collectionRef =
+        _firestore.collection('analytics').doc('screen_time').collection('all');
+    final docRef = collectionRef.doc(screenName);
+    print('Recording screen time for $screenName: $timeSpent seconds');
+    try {
+      // Fetch the document to update average time
+      final document = await docRef.get();
+      if (document.exists) {
+        final currentAvgTime = (document['average_time'] ?? 0.0);
+        final visitCount = (document['visit_count'] ?? 0);
+
+        final double safeCurrentAvgTime = (currentAvgTime is int)
+            ? currentAvgTime.toDouble()
+            : currentAvgTime as double;
+        final int safeVisitCount = visitCount as int;
+
+        final newAvgTime = ((safeCurrentAvgTime * safeVisitCount) + timeSpent) /
+            (safeVisitCount + 1);
+
+        await docRef.update({
+          'average_time': newAvgTime,
+          'visit_count': visitCount + 1,
+        });
+        print('Successfully updated average screen time in Firestore');
+      } else {
+        await docRef.set({
+          'average_time': timeSpent,
+          'visit_count': 1,
+        }, SetOptions(merge: true));
+        print('Successfully set average screen time in Firestore');
+      }
+    } catch (error) {
+      print('Error updating document: $error');
+    }
+
+    _startTime = null;
+  }
+}

--- a/lib/views/initiation_view.dart
+++ b/lib/views/initiation_view.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import 'package:isis3510_team32_flutter/constants/errors.dart';
 import 'package:isis3510_team32_flutter/constants/sports.dart';
 import 'package:isis3510_team32_flutter/core/app_colors.dart';
+import 'package:isis3510_team32_flutter/core/screen_time.service.dart';
 import 'package:isis3510_team32_flutter/models/data_models/user_model.dart';
 import 'package:isis3510_team32_flutter/view_models/auth/auth_bloc.dart';
 import 'package:isis3510_team32_flutter/view_models/auth/auth_event.dart';
@@ -23,11 +24,15 @@ import 'package:isis3510_team32_flutter/widgets/initiation_view/initiation_date_
 import 'package:isis3510_team32_flutter/widgets/initiation_view/initiation_icon_toggle_button_widget.dart';
 
 class InitiationView extends StatelessWidget {
-  const InitiationView({super.key});
+  final ScreenTimeService screenTimeService;
+
+  const InitiationView({super.key, required this.screenTimeService});
 
   @override
   Widget build(BuildContext context) {
     FirebaseCrashlytics.instance.setCustomKey('screen', 'Initiation View');
+
+    screenTimeService.startTrackingTime();
 
     final size = MediaQuery.of(context).size;
     final aspectRatio = size.width / size.height;
@@ -71,11 +76,13 @@ class InitiationView extends StatelessWidget {
                       Expanded(
                         child: IndexedStack(
                           index: state.currentStep,
-                          children: const [
-                            InitiationNameView(),
-                            InititationGenderView(),
-                            InititationAgeView(),
-                            InitiationSportView(),
+                          children: [
+                            const InitiationNameView(),
+                            const InititationGenderView(),
+                            const InititationAgeView(),
+                            InitiationSportView(
+                              screenTimeService: screenTimeService,
+                            ),
                           ],
                         ),
                       ),
@@ -116,7 +123,6 @@ class _InitiationNameViewState extends State<InitiationNameView> {
   @override
   Widget build(BuildContext context) {
     final initiationBloc = context.read<InitiationBloc>();
-    final authBloc = context.read<AuthBloc>();
 
     final size = MediaQuery.of(context).size;
     final aspectRatio = size.width / size.height;
@@ -353,7 +359,8 @@ class InititationAgeView extends StatelessWidget {
 }
 
 class InitiationSportView extends StatelessWidget {
-  const InitiationSportView({super.key});
+  final ScreenTimeService screenTimeService;
+  const InitiationSportView({super.key, required this.screenTimeService});
 
   @override
   Widget build(BuildContext context) {
@@ -481,6 +488,10 @@ class InitiationSportView extends StatelessWidget {
                               .add(ConnectivityRequestedFetchEvent());
                           return;
                         }
+
+                        await screenTimeService
+                            .stopAndRecordTime('Initiation View');
+
                         loadingBloc.add(ShowLoadingEvent());
                         authBloc.add(
                           AuthCreateModelEvent(

--- a/lib/views/initiation_view.dart
+++ b/lib/views/initiation_view.dart
@@ -489,9 +489,6 @@ class InitiationSportView extends StatelessWidget {
                           return;
                         }
 
-                        await screenTimeService
-                            .stopAndRecordTime('Initiation View');
-
                         loadingBloc.add(ShowLoadingEvent());
                         authBloc.add(
                           AuthCreateModelEvent(
@@ -504,6 +501,8 @@ class InitiationSportView extends StatelessWidget {
                             ),
                           ),
                         );
+                        await screenTimeService
+                            .stopAndRecordTime('Initiation View');
                       }
                     : null,
                 child: const Text(


### PR DESCRIPTION
This pull request introduces a new `ScreenTimeService` to track and record user screen time for analytics purposes. The service is integrated into the routing and two views (`CreateBookingView` and `InitiationView`) to measure time spent on these screens and update the analytics data in Firebase.

### New Feature: Screen Time Tracking

* **`ScreenTimeService` Implementation**:
  - Added a new `ScreenTimeService` class in `lib/core/screen_time.service.dart` to track screen time and update Firebase analytics. It includes methods to start tracking time, stop tracking time, and update average time and visit counts in Firestore.

### Integration with Router and Views

* **Router Updates**:
  - Modified `lib/core/go_router.dart` to initialize the `ScreenTimeService` and pass it as a dependency to the `CreateBookingView` and `InitiationView` routes. [[1]](diffhunk://#diff-2fd21416f4e240709105d1150cd83785fedb3562714e6d99e75fc9498c2b6d8eR3) [[2]](diffhunk://#diff-2fd21416f4e240709105d1150cd83785fedb3562714e6d99e75fc9498c2b6d8eR30) [[3]](diffhunk://#diff-2fd21416f4e240709105d1150cd83785fedb3562714e6d99e75fc9498c2b6d8eL96-R108)

* **`CreateBookingView` Updates**:
  - Updated `CreateBookingView` to accept `ScreenTimeService` as a parameter. Added logic to start tracking time on view load and stop tracking time when the booking button is clicked. [[1]](diffhunk://#diff-c186931a1a95705ed31d842f895e4a96b7b3887af83f78e89d5b6d22a83c188bR7) [[2]](diffhunk://#diff-c186931a1a95705ed31d842f895e4a96b7b3887af83f78e89d5b6d22a83c188bR23-R52) [[3]](diffhunk://#diff-c186931a1a95705ed31d842f895e4a96b7b3887af83f78e89d5b6d22a83c188bL127-R139) [[4]](diffhunk://#diff-c186931a1a95705ed31d842f895e4a96b7b3887af83f78e89d5b6d22a83c188bR154-R157) [[5]](diffhunk://#diff-c186931a1a95705ed31d842f895e4a96b7b3887af83f78e89d5b6d22a83c188bR180-R182)

* **`InitiationView` Updates**:
  - Updated `InitiationView` and its subviews to accept `ScreenTimeService` as a parameter. Added logic to start tracking time on view load and stop tracking time when the initiation process is completed. [[1]](diffhunk://#diff-b34e333c66e855554e7d115259720be73cc5ae90c4ea0bceb15bb67bfe92bd3fR9) [[2]](diffhunk://#diff-b34e333c66e855554e7d115259720be73cc5ae90c4ea0bceb15bb67bfe92bd3fL26-R36) [[3]](diffhunk://#diff-b34e333c66e855554e7d115259720be73cc5ae90c4ea0bceb15bb67bfe92bd3fL74-R85) [[4]](diffhunk://#diff-b34e333c66e855554e7d115259720be73cc5ae90c4ea0bceb15bb67bfe92bd3fL356-R363) [[5]](diffhunk://#diff-b34e333c66e855554e7d115259720be73cc5ae90c4ea0bceb15bb67bfe92bd3fR504-R505)

These changes ensure that screen time data is consistently tracked and recorded for analytics, providing valuable insights into user behavior.