### PR TITLE
Fix/eventual connectivity home view

### DIFF
--- a/lib/constants/errors.dart
+++ b/lib/constants/errors.dart
@@ -31,6 +31,21 @@ void showNoConnectionError(BuildContext context) {
   ).show(context);
 }
 
+void showNoConnectionErrorJoinBooking(BuildContext context) {
+  Flushbar(
+    title: "No Internet Connection",
+    message:
+        "Please check your internet connection and try again. You cannot join a booking without connection.",
+    icon: const Icon(
+      Icons.info_rounded,
+      size: 16,
+      color: Colors.red,
+    ),
+    leftBarIndicatorColor: Colors.red,
+    duration: const Duration(seconds: 5),
+  ).show(context);
+}
+
 void showIncompleteFieldsError(BuildContext context) {
   Flushbar(
     title: "Incomplete Fields",

--- a/lib/widgets/home_view/recommended_booking_card_widget.dart
+++ b/lib/widgets/home_view/recommended_booking_card_widget.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:isis3510_team32_flutter/constants/errors.dart';
@@ -103,11 +104,23 @@ class RecommendedBookingCardWidget extends StatelessWidget {
                 topLeft: Radius.circular(15.0),
                 bottomLeft: Radius.circular(15.0),
               ),
-              child: Image.network(
-                booking.venue.image,
+              child: CachedNetworkImage(
+                imageUrl: booking.venue.image,
                 width: 120,
                 height: 120,
                 fit: BoxFit.cover,
+                placeholder: (context, url) => const Center(
+                    child: SizedBox(
+                  width: 120.0,
+                  height: 120.0,
+                  child: CircularProgressIndicator(),
+                )),
+                errorWidget: (context, url, error) => const Center(
+                    child: SizedBox(
+                  width: 120.0,
+                  height: 120.0,
+                  child: Icon(Icons.broken_image),
+                )),
               ),
             ),
             Expanded(

--- a/lib/widgets/home_view/recommended_booking_card_widget.dart
+++ b/lib/widgets/home_view/recommended_booking_card_widget.dart
@@ -56,6 +56,14 @@ class RecommendedBookingCardWidget extends StatelessWidget {
                 ),
                 TextButton(
                   onPressed: () async {
+                    final connectivityState = connectivityBloc.state;
+
+                    if (connectivityState is ConnectivityOfflineState) {
+                      Navigator.of(dialogContext).pop();
+                      showNoConnectionErrorJoinBooking(context);
+                      return;
+                    }
+
                     Navigator.of(dialogContext).pop();
 
                     loadingBloc.add(ShowLoadingEvent());

--- a/lib/widgets/venue_detail_widgets/booking_info_card.dart
+++ b/lib/widgets/venue_detail_widgets/booking_info_card.dart
@@ -61,6 +61,14 @@ class BookingInfoCard extends StatelessWidget {
                 ),
                 TextButton(
                   onPressed: () async {
+                    final connectivityState = connectivityBloc.state;
+
+                    if (connectivityState is ConnectivityOfflineState) {
+                      Navigator.of(dialogContext).pop();
+                      showNoConnectionErrorJoinBooking(context);
+                      return;
+                    }
+
                     Navigator.of(dialogContext).pop();
 
                     loadingBloc.add(ShowLoadingEvent());


### PR DESCRIPTION
This pull request introduces improvements to error handling and image loading in the app. Key changes include adding a new error message for offline connectivity when attempting to join a booking, implementing cached image loading with placeholders and error widgets, and updating the logic in relevant widgets to handle connectivity checks.

### Error Handling Improvements:
* Added a new method `showNoConnectionErrorJoinBooking` in `lib/constants/errors.dart` to display an error message when the user tries to join a booking without an internet connection.
* Updated `RecommendedBookingCardWidget` and `BookingInfoCard` to check the connectivity state before allowing the user to proceed with booking actions. Displays the new error message if offline. [[1]](diffhunk://#diff-589cb26764ba54d4598129ab35c0504c1cda1c333187f633471ae1f79c4b2de3R59-R66) [[2]](diffhunk://#diff-8469f2b5a5ea4afd73be4c8212cb93954fe36beaced48dabc1af5cc4ca73efc5R64-R71)

### Image Loading Enhancements:
* Replaced `Image.network` with `CachedNetworkImage` in `RecommendedBookingCardWidget` to improve image loading performance. Added a placeholder (loading spinner) and an error widget (broken image icon) for better user experience.
* Imported the `cached_network_image` package in `lib/widgets/home_view/recommended_booking_card_widget.dart` to support the new image loading functionality.