### PR TITLE
fix/sport-icons

### DIFF
--- a/lib/constants/sports.dart
+++ b/lib/constants/sports.dart
@@ -22,3 +22,22 @@ Map<String, SportModel> initiationSports = {
       logo:
           "https://firebasestorage.googleapis.com/v0/b/moviles-isis3510.firebasestorage.app/o/icons%2Fsports%2Ftennis-logo-svg.svg?alt=media&token=b9441062-25d4-4da5-9220-2e0c27c30792"),
 };
+
+Map<String, SportModel> sportLocal = {
+  "basketball": SportModel(
+      id: "basketball",
+      name: "Basketball",
+      logo: "assets/icons/initiation/basketball-logo.svg"),
+  "football": SportModel(
+      id: "football",
+      name: "Football",
+      logo: "assets/icons/initiation/football-logo.svg"),
+  "volleyball": SportModel(
+      id: "volleyball",
+      name: "Volleyball",
+      logo: "assets/icons/initiation/volleyball-logo.svg"),
+  "tennis": SportModel(
+      id: "tennis",
+      name: "Tennis",
+      logo: "assets/icons/initiation/tennis-logo.svg"),
+};

--- a/lib/view_models/search/search_bloc.dart
+++ b/lib/view_models/search/search_bloc.dart
@@ -15,7 +15,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
       LoadSearchData event, Emitter<SearchState> emit) async {
     emit(SearchLoading());
     try {
-      final sports = initiationSports.values.toList();
+      final sports = sportLocal.values.toList();
       emit(SearchLoaded(sports: sports));
     } catch (e) {
       emit(SearchError('Failed to load search data: $e'));

--- a/lib/views/profile_view.dart
+++ b/lib/views/profile_view.dart
@@ -352,7 +352,7 @@ class ProfileCardFavoriteSportsWidget extends StatelessWidget {
                         child: ClipOval(
                           child: Center(
                             child: SvgPicture.asset(
-                              initiationSports[sport.id]!.logo,
+                              sportLocal[sport.id]!.logo,
                               width: 40,
                               height: 40,
                               colorFilter: const ColorFilter.mode(


### PR DESCRIPTION
This pull request introduces a new `sportLocal` map to replace the existing `initiationSports` map for managing sports data locally. The changes update references across the codebase to use the new `sportLocal` map, ensuring a consistent and centralized approach to accessing sports data.

### Introduction of `sportLocal` map:
* [`lib/constants/sports.dart`](diffhunk://#diff-cb7ebd6c8659097c5bd3651f738e5b4f57b6dd820c09e664df88d0d85c6c170cR25-R43): Added a new `sportLocal` map containing sports data with local asset paths for logos, replacing the previous reliance on remote URLs.

### Updates to use `sportLocal`:
* [`lib/view_models/search/search_bloc.dart`](diffhunk://#diff-dec7a92b0aace2bcce9f46476066793897c628c58fd16607287226e88af2d635L18-R18): Updated the `SearchBloc` class to use `sportLocal` instead of `initiationSports` for loading sports data in the `LoadSearchData` event.
* [`lib/views/profile_view.dart`](diffhunk://#diff-76242abbe30ee0e85490fb511da266efbd5dbd51b4a939ddf40212acf3062b0aL355-R355): Modified the `ProfileCardFavoriteSportsWidget` to reference `sportLocal` for retrieving sports logos.…d profile views