### PR TITLE
feat: implement caching for booking state

### DIFF
--- a/lib/view_models/create_booking/create_booking_state.dart
+++ b/lib/view_models/create_booking/create_booking_state.dart
@@ -16,10 +16,11 @@ class CreateBookingState {
     String? timeSlot,
     int? maxUsers,
     bool? success,
+    bool overrideTimeSlot = false,
   }) {
     return CreateBookingState(
       date: date ?? this.date,
-      timeSlot: timeSlot ?? this.timeSlot,
+      timeSlot: overrideTimeSlot ? timeSlot : (timeSlot ?? this.timeSlot),
       maxUsers: maxUsers ?? this.maxUsers,
       success: success ?? this.success,
     );

--- a/lib/view_models/theme/theme_bloc.dart
+++ b/lib/view_models/theme/theme_bloc.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:isis3510_team32_flutter/core/theme_frecuency_service.dart';
 import 'package:isis3510_team32_flutter/view_models/theme/theme_event.dart';

--- a/lib/widgets/create_booking_view/time_slot_selector_widget.dart
+++ b/lib/widgets/create_booking_view/time_slot_selector_widget.dart
@@ -145,7 +145,7 @@ class TimeSlotSelectorWidget extends StatelessWidget {
                                     iconSize: 20,
                                     style: const TextStyle(fontSize: 14),
                                     items: List.generate(
-                                            12, (index) => index + 1)
+                                            22, (index) => index + 1)
                                         .map((playerCount) =>
                                             DropdownMenuItem<int>(
                                               value: playerCount,


### PR DESCRIPTION
This pull request introduces caching for user inputs in the `CreateBookingBloc` using an `LRUCache` and makes a minor bug fix in the `CreateBookingState`. Additionally, it includes a small cleanup in the `ThemeBloc`. Below are the most important changes grouped by theme:

### Caching Implementation in `CreateBookingBloc`:
* Added an `LRUCache` to store user choices (`date`, `timeSlot`, `maxUsers`) in `CreateBookingBloc` to persist user inputs across sessions. (`lib/view_models/create_booking/create_booking_bloc.dart`)
* Introduced a `_initializeState` method to initialize `CreateBookingState` with cached values if available, or default values otherwise. (`lib/view_models/create_booking/create_booking_bloc.dart`)

### Bug Fix in `CreateBookingState`:
* Fixed the logic in the `copyWith` method of `CreateBookingState` to allow overriding the `timeSlot` value when explicitly specified. (`lib/view_models/create_booking/create_booking_state.dart`)

### Code Cleanup:
* Removed an unused `import` statement from `ThemeBloc`, improving code cleanliness. (`lib/view_models/theme/theme_bloc.dart`)