### PR TITLE
refactor: validate booking fields before checking connectivity status

### DIFF
--- a/lib/views/create_booking_view.dart
+++ b/lib/views/create_booking_view.dart
@@ -186,10 +186,13 @@ class _CreateBookingButton extends StatelessWidget {
                             .stopAndRecordTime('Create Booking View');
                       }
                     : () {
-                        if (connectivityState is ConnectivityOfflineState) {
-                          showNoConnectionError(context);
-                        } else {
+                        if (state.date == null ||
+                            state.timeSlot == null ||
+                            state.maxUsers == null) {
                           showIncompleteFieldsError(context);
+                        } else if (connectivityState
+                            is ConnectivityOfflineState) {
+                          showNoConnectionError(context);
                         }
                       },
                 style: ElevatedButton.styleFrom(


### PR DESCRIPTION
This pull request updates the `_CreateBookingButton` class in `lib/views/create_booking_view.dart` to improve error handling when creating a booking. The most significant change ensures that incomplete fields are checked before verifying connectivity status.

### Error Handling Improvements:
* Updated the button's `onPressed` callback to first check if required fields (`date`, `timeSlot`, `maxUsers`) are null and display an `showIncompleteFieldsError` if any are missing. The connectivity check (`ConnectivityOfflineState`) is now handled only after this validation.