### PR TITLE
feat: add event to overwrite time slot in booking process

### DIFF
--- a/lib/view_models/create_booking/create_booking_bloc.dart
+++ b/lib/view_models/create_booking/create_booking_bloc.dart
@@ -17,13 +17,15 @@ class CreateBookingBloc extends Bloc<CreateBookingEvent, CreateBookingState> {
       : super(_initializeState()) {
     on<CreateBookingDateEvent>((event, emit) {
       _cache.put('date', event.date); // Save to cache
-      _cache.put('timeSlot', null);
-      emit(state.copyWith(
-          date: event.date, timeSlot: null, overrideTimeSlot: true));
+      emit(state.copyWith(date: event.date));
     });
     on<CreateBookingTimeSlotEvent>((event, emit) {
       _cache.put('timeSlot', event.timeSlot); // Save to cache
       emit(state.copyWith(timeSlot: event.timeSlot));
+    });
+    on<CreateBookingTimeSlotEventOverwrite>((event, emit) {
+      _cache.put('timeSlot', null); // Save to cache
+      emit(state.copyWith(timeSlot: null, overrideTimeSlot: true));
     });
     on<CreateBookingMaxUsersEvent>((event, emit) {
       _cache.put('maxUsers', event.maxUsers); // Save to cache

--- a/lib/view_models/create_booking/create_booking_event.dart
+++ b/lib/view_models/create_booking/create_booking_event.dart
@@ -10,6 +10,10 @@ class CreateBookingTimeSlotEvent extends CreateBookingEvent {
   CreateBookingTimeSlotEvent(this.timeSlot);
 }
 
+class CreateBookingTimeSlotEventOverwrite extends CreateBookingEvent {
+  CreateBookingTimeSlotEventOverwrite();
+}
+
 class CreateBookingMaxUsersEvent extends CreateBookingEvent {
   int maxUsers;
   CreateBookingMaxUsersEvent(this.maxUsers);

--- a/lib/widgets/create_booking_view/time_slot_selector_widget.dart
+++ b/lib/widgets/create_booking_view/time_slot_selector_widget.dart
@@ -46,6 +46,13 @@ class TimeSlotSelectorWidget extends StatelessWidget {
                   builder: (context, snapshot) {
                     final timeSlots = snapshot.data ?? [];
 
+                    if (state.timeSlot != null &&
+                        timeSlots.isNotEmpty &&
+                        !timeSlots.contains(state.timeSlot)) {
+                      createBookingBloc
+                          .add(CreateBookingTimeSlotEventOverwrite());
+                    }
+
                     if (timeSlots.isEmpty) {
                       return const Center(
                         child: Text(


### PR DESCRIPTION
This pull request introduces changes to the `CreateBookingBloc` and related components to improve the handling of time slot state when invalid or unavailable time slots are detected. The most important updates include adding a new event class, modifying the bloc to handle this event, and updating the UI logic to trigger the new event when necessary.

### Bloc updates:
* [`lib/view_models/create_booking/create_booking_bloc.dart`](diffhunk://#diff-e663c01b6d717a659de8891271a9666962d444313a979924eeb6ad7084aed2a6L20-R29): Added a new event handler for `CreateBookingTimeSlotEventOverwrite` to reset the `timeSlot` state and enable overriding when an invalid or unavailable time slot is detected.

### Event class addition:
* [`lib/view_models/create_booking/create_booking_event.dart`](diffhunk://#diff-7022d3582870a039f9e3263bfcf1a35f6338429e1cb853d6bd866905ecb9a27aR13-R16): Introduced the `CreateBookingTimeSlotEventOverwrite` class to represent the new event for resetting the time slot state.

### UI logic enhancement:
* [`lib/widgets/create_booking_view/time_slot_selector_widget.dart`](diffhunk://#diff-1ce1d17cfdc3d5dc56fcc348979affb64d3c03a6243534315cddcbce9e6dc058R49-R55): Updated the `TimeSlotSelectorWidget` to check if the current `timeSlot` is invalid or unavailable in the list of time slots, and dispatch the `CreateBookingTimeSlotEventOverwrite` event when necessary.